### PR TITLE
Add Padded floppy images for some (iLO/iDRAC) Remote Management Consoles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 |------|------------|-------------|
 |Kernel| [netboot.xyz.lkrn](https://boot.netboot.xyz/ipxe/netboot.xyz.lkrn)|Used for booting from GRUB/EXTLINUX|
 |Floppy| [netboot.xyz.dsk](https://boot.netboot.xyz/ipxe/netboot.xyz.dsk)| Virtual floppy disk for DRAC/iLO, VMware, Virtual Box, etc|
+|Padded Floppy| [netboot.xyz.pdsk](https://boot.netboot.xyz/ipxe/netboot.xyz.pdsk)| Padded Virtual floppy disk for DRAC/iLO, VMware, Virtual Box, etc|
 |DHCP| [netboot.xyz.kpxe](https://boot.netboot.xyz/ipxe/netboot.xyz.kpxe)| DHCP boot image file, uses built-in iPXE NIC drivers|
 |DHCP-undionly| [netboot.xyz-undionly.kpxe](https://boot.netboot.xyz/ipxe/netboot.xyz-undionly.kpxe)| DHCP boot image file, use if you have NIC issues|
 

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -37,6 +37,10 @@ bootloaders:
     ipxe_bin: ipxe.dsk
     output_bin: .dsk
     type: Floppy
+  - desc: Padded Virtual floppy disk for DRAC/iLO, VMware, Virtual Box, etc
+    ipxe_bin: ipxe.pdsk
+    output_bin: .pdsk
+    type: Floppy
   - desc: DHCP boot image file, uses built-in iPXE NIC drivers
     ipxe_bin: ipxe.kpxe
     output_bin: .kpxe

--- a/roles/netbootxyz/tasks/generate_disks_legacy.yml
+++ b/roles/netbootxyz/tasks/generate_disks_legacy.yml
@@ -26,6 +26,7 @@
       make EMBED={{ bootloader_filename }} \
            TRUST={{ trust_files }} \
            bin/ipxe.dsk \
+           bin/ipxe.pdsk \
            bin/ipxe.lkrn \
            bin/ipxe.kpxe \
            bin/undionly.kpxe
@@ -42,6 +43,7 @@
            DEBUG={{ ipxe_debug_options }} \
            TRUST={{ trust_files }} \
            bin/ipxe.dsk \
+           bin/ipxe.pdsk \
            bin/ipxe.lkrn \
            bin/ipxe.kpxe \
            bin/undionly.kpxe
@@ -57,6 +59,7 @@
       dest: "{{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}{{ item }}"
       remote_src: True
     with_items:
+    - ".pdsk"
     - ".dsk"
     - ".lkrn"
     - ".kpxe"


### PR DESCRIPTION
Hello, 

some new versions of redfish need exactly 1,44mb, so that image can be uploaded. ipxe has already padded version of this images. I think it's helpfull to some people to have this just for download.

Best Regards,
Juri