### PR TITLE
fix grml version (2022.11 -> 2024.02)

### DIFF
--- a/endpoints.yml
+++ b/endpoints.yml
@@ -251,7 +251,7 @@ endpoints:
     - initrd
     - vmlinuz
     os: grml
-    version: '2022.11'
+    version: '2024.02'
     flavor: full
   grml-small:
     path: /debian-squash/releases/download/2024.02-7d326c39/
@@ -260,7 +260,7 @@ endpoints:
     - initrd
     - vmlinuz
     os: grml
-    version: '2022.11'
+    version: '2024.02'
     flavor: small
   gparted-stable:
     path: /debian-squash/releases/download/1.6.0-3-cff72999/


### PR DESCRIPTION
grml has been bumped to version 2024.02 on June 25:

- https://github.com/netbootxyz/netboot.xyz/commit/0fd24443acc96c12b78a396cc4cbe5c14f769d88

- https://github.com/netbootxyz/netboot.xyz/commit/20370831157590db23e5fed179df16c59f40963f

But the menu still shows the old version (2022.11).

