### PR TITLE
fix: remove hardcoded http:// prefix from archlinux_mirror URLs

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -165,7 +165,7 @@ releases:
     base_dir: archlinux
     enabled: true
     menu: linux
-    mirror: mirrors.kernel.org
+    mirror: http://mirrors.kernel.org
     name: Arch Linux
     versions:
     - code_name: 2025.11.01

--- a/roles/netbootxyz/templates/menu/archlinux.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/archlinux.ipxe.j2
@@ -36,9 +36,9 @@ iseq ${os_arch} i686 && goto boot32 ||
 :boot
 imgfree
 set dir ${archlinux_base_dir}/iso/${arch_version}/arch/boot
-set params archiso_http_srv=http://${real_archlinux_mirror}/${archlinux_base_dir}/iso/${arch_version}/ archisobasedir=arch cms_verify=y ${ipparam} net.ifnames=0 {{ kernel_params }}
-kernel http://${archlinux_mirror}/${dir}/${os_arch}/vmlinuz-linux ${params}
-initrd http://${archlinux_mirror}/${dir}/${os_arch}/initramfs-linux.img
+set params archiso_http_srv=${real_archlinux_mirror}/${archlinux_base_dir}/iso/${arch_version}/ archisobasedir=arch cms_verify=y ${ipparam} net.ifnames=0 {{ kernel_params }}
+kernel ${archlinux_mirror}/${dir}/${os_arch}/vmlinuz-linux ${params}
+initrd ${archlinux_mirror}/${dir}/${os_arch}/initramfs-linux.img
 echo
 echo MD5sums:
 md5sum vmlinuz-linux initramfs-linux.img


### PR DESCRIPTION
Fixes issue where setting archlinux_mirror to an HTTPS URL would result in malformed URLs like http://https://mirror.example.com/...

Changes:
- Remove hardcoded http:// prefix from archiso_http_srv parameter
- Remove hardcoded http:// prefix from kernel URL
- Remove hardcoded http:// prefix from initrd URL
- Add http:// prefix to default archlinux mirror for backward compatibility

Now respects the protocol specified in the archlinux_mirror configuration, allowing both HTTP and HTTPS mirrors to work correctly.

Fixes #1703