### PR TITLE
Update OpenBSD, enable BSD on UEFI

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -401,18 +401,18 @@ releases:
     base_dir: pub/OpenBSD
     enabled: true
     menu: bsd
-    mirror: http://ftp.openbsd.org
+    mirror: http://cdn.openbsd.org
     name: OpenBSD
     versions:
+    - code_name: snapshots
+      image_ver: '78'
+      name: 7.8 Latest Snapshot
+    - code_name: '7.8'
+      image_ver: '78'
+      name: '7.8'
     - code_name: '7.7'
       image_ver: '77'
       name: '7.7'
-    - code_name: '7.6'
-      image_ver: '76'
-      name: '7.6'
-    - code_name: snapshots
-      image_ver: '77'
-      name: 7.7 Latest Snapshot
   opensuse:
     base_dir: distribution/leap
     enabled: true

--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -82,7 +82,7 @@ set menu_pci 0
 iseq ${platform} efi && goto efi ||
 goto architectures_end
 :efi
-set menu_bsd 0
+set menu_bsd 1
 set menu_freedos 0
 set menu_unix 0
 set menu_pci 0
@@ -121,7 +121,7 @@ goto clouds_end
 :metal_arm64
 set cmdline console=ttyAMA0,115200
 set ipxe_disk netboot.xyz-metal-arm64-snp.efi
-set menu_bsd 0
+set menu_bsd 1
 set menu_freedos 0
 set menu_live 0
 set menu_windows 0

--- a/roles/netbootxyz/templates/menu/bsd.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/bsd.ipxe.j2
@@ -10,7 +10,11 @@ menu BSD Installers - Current Arch [ ${arch} ]
 item --gap BSD Based Operating Systems
 {% for key, value in releases.items() | sort(attribute='1.name') %}
 {% if value.enabled is defined and value.menu == "bsd" and value.enabled | bool %}
+{% if key == "freebsd" %}
+iseq ${platform} efi || item {{ key }} ${space} {{ value.name }}
+{% else %}
 item {{ key }} ${space} {{ value.name }}
+{% endif %}
 {% endif %}
 {% endfor %}
 choose menu || goto bsd_exit

--- a/roles/netbootxyz/templates/menu/openbsd.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/openbsd.ipxe.j2
@@ -30,7 +30,7 @@ chain ${memdisk} iso raw
 goto openbsd_menu
 
 :efi_boot
-set src ${openbsd_mirror}/${openbsd_base_dir}/${ver}/${os_arch}/install${image_ver}.img
+set src ${openbsd_mirror}/${openbsd_base_dir}/${ver}/${os_arch}/miniroot${image_ver}.img
 imgfree
 sanboot ${src}
 goto openbsd_menu


### PR DESCRIPTION
Built on Ubuntu 22.04 and boot tested on real hardware as well as in QEMU.

The only currently supported BSDs are FreeBSD and OpenBSD.

FreeBSD overall remains unchanged, i.e. still only available on amd64+pcbios.

OpenBSD becomes available on arm64/amd64+efi.