### PR TITLE
Use .startswith() in filter to only check major version in live-debia…

### DIFF
--- a/roles/netbootxyz/templates/menu/live-debian.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-debian.ipxe.j2
@@ -14,7 +14,7 @@ goto ${live_version}
 
 :trixie
 {% for key, value in endpoints.items() | sort %}
-{% if value.os == "debian" and 'squash' in key and value.version == "13" %}
+{% if value.os == "debian" and 'squash' in key and value.version.startswith("13") %}
 item {{ key }} ${space} {{ value.os | title }} {{ value.version }} {{ value.flavor | title}}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
The version for Live Debian images in `endpoints.yml` are specified as `"13.4.0"`, while the template conditional attempt to check equality with `"13"`. I changed the conditional to check that version starts with `"13"`.

Another option would be to specify the full version in the template conditional, but that will most likely just be a maintenance hassle.

Edit: The background for this PR is that http://boot.netboot.xyz/live-debian.ipxe currently does not have any items in the `:trixie` menu, due to the overly strict filter. So there is currently no Live Debian image available from the public netboot.xyz menu. Should this be handled as an Issue instead?