### PR TITLE
Add 26.04 LTS Resolute Raccoon

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -744,6 +744,8 @@ releases:
     mirror: http://archive.ubuntu.com
     name: Ubuntu
     versions:
+    - code_name: resolute
+      name: 26.04 LTS Resolute Raccoon
     - code_name: questing
       name: 25.10 Questing Quokka
     - code_name: plucky


### PR DESCRIPTION
## Summary
- Add Ubuntu 26.04 LTS (Resolute Raccoon) to the Ubuntu installer menu

Netboot kernel/initrd assets are published from the new `ubuntu-netboot-26.04-amd64` and `ubuntu-netboot-26.04-arm64` branches in `netbootxyz/ubuntu-squash`; their endpoints will be added by the build pipeline's auto version-bump.

## Test plan
- [ ] `ansible-playbook site.yml --syntax-check`
- [ ] `ansible-lint -v roles/netbootxyz/tasks`
- [ ] `./script/build_release pr`
- [ ] Boot Ubuntu menu and confirm `26.04 LTS Resolute Raccoon` appears under Latest Releases