### PR TITLE
Add Omarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ In addition to being able to host netboot.xyz locally, you can also create your 
 | MirOS                           | http://www.mirbsd.org | Yes | No |
 | Nitrux                          | https://nxos.org/ | No | Yes |
 | NixOS                           | https://nixos.org | Yes | No |
+| Omarchy                         | https://omarchy.org | No | Yes |
 | OpenBSD                         | https://openbsd.org | Yes | No |
 | openEuler                       | https://openeuler.org | Yes | No |
 | openSUSE                        | https://opensuse.org | Yes | No |

--- a/roles/netbootxyz/templates/menu/live-omarchy.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-omarchy.ipxe.j2
@@ -1,0 +1,39 @@
+#!ipxe
+
+# Omarchy Operating System
+# https://omarchy.org
+
+goto ${menu} ||
+
+:live_menu
+set os Omarchy
+menu ${os}
+set ipparam BOOTIF=${netX/mac} ip=dhcp net.ifnames=0
+item --gap ${os} Versions
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "omarchy" %}
+item {{ value.version }} ${space} ${os} {{ value.version }}
+{% endif %}
+{% endfor %}
+choose live_version || goto live_exit
+goto ${live_version}
+
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "omarchy" %}
+:{{ value.version }}
+set url ${live_endpoint}{{ value.path }}
+goto boot
+
+{% endif %}
+{% endfor %}
+
+:boot
+imgfree
+kernel ${url}vmlinuz ${ipparam} archiso_http_srv=${url} cow_spacesize=10G copytoram=auto module_blacklist=nvidia,nvidia_modeset,nvidia_uvm,nvidia_drm,pcspkr nouveau.modeset=1 i915.modeset=1 radeon.modeset=1 nvme_load=yes initrd=initrd.magic console=tty1 {{ kernel_params }}
+initrd ${url}initrd
+initrd ${url}archiso_pxe_http /hooks/archiso_pxe_http mode=755
+boot
+
+:live_exit
+clear menu
+exit 0

--- a/roles/netbootxyz/templates/menu/live.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live.ipxe.j2
@@ -28,6 +28,7 @@ item live-lxle ${space} LXLE
 item live-manjaro ${space} Manjaro
 item live-mint ${space} Mint
 item live-nitrux ${space} Nitrux
+item live-omarchy ${space} Omarchy
 item live-parrot ${space} Parrot OS
 item live-peppermint ${space} Peppermint
 item live-popos ${space} Pop OS


### PR DESCRIPTION
## Summary
- Add a live boot menu entry for [Omarchy](https://omarchy.org), an Arch-based distribution.
- Adds `live-omarchy.ipxe.j2` modeled directly on `live-cachyos.ipxe.j2` (same archiso PXE flow: `airootfs.sfs`, `initrd`, `vmlinuz`, `archiso_pxe_http`).
- Endpoint already present in `endpoints.yml` (`omarchy` 3.6.0, asset-mirror release `3.6.0-1f22f020`) — this PR wires up the menu and README entry.

## Changes
- `roles/netbootxyz/templates/menu/live-omarchy.ipxe.j2` — new template
- `roles/netbootxyz/templates/menu/live.ipxe.j2` — adds `item live-omarchy ${space} Omarchy` (alphabetical)
- `README.md` — adds Omarchy row to the OS table

## Test plan
- [ ] Build menus locally (`ansible-playbook site.yml` or Docker build) and confirm `live-omarchy.ipxe` is generated in `buildout/`
- [ ] Boot iPXE, navigate Live Boot Distributions → Omarchy → 3.6.0
- [ ] Verify kernel/initrd fetch from asset-mirror release `3.6.0-1f22f020`
- [ ] Verify the live image boots into the Omarchy environment