### PR TITLE
fix(menu): break custom menu fallback loop when chain fails

### DIFF
--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -126,13 +126,17 @@ chain https://boot.netboot.xyz/about.ipxe || chain about.ipxe
 goto main_menu
 
 :custom-github
-chain https://raw.githubusercontent.com/${github_user}/netboot.xyz-custom/master/custom.ipxe || goto error
+chain https://raw.githubusercontent.com/${github_user}/netboot.xyz-custom/master/custom.ipxe || goto custom-failed
 goto main_menu
 
 :custom-url
-chain ${custom_url}/custom.ipxe || goto error
+chain ${custom_url}/custom.ipxe || goto custom-failed
 goto main_menu
 
 :custom-user
-chain custom/custom.ipxe
+chain custom/custom.ipxe || goto custom-failed
 goto main_menu
+
+:custom-failed
+clear menu
+goto error


### PR DESCRIPTION
## Summary
- Fixes #1795 — when `boot.cfg` set `${menu}` (e.g. `set menu custom-user`) and the local custom chain failed, the variable persisted across every HTTPS/HTTP × IPv6/IPv4 fallback the bootloader attempted, so each retry redispatched to `:custom-user` and tried to chain `custom/custom.ipxe` from `boot.netboot.xyz` (which has no such file). The result was a tight, never-rendering loop.
- `clear menu` on chain failure so the next dispatch — local or after fallback to the public server — renders the actual main menu instead of repeating the failed custom path.
- Applies the same pattern to `:custom-github` and `:custom-url`, which share the same root cause if a user pre-sets the corresponding `menu` value.

## Trace of the bug (before this change)
1. Local `boot.cfg` runs `set menu custom-user`.
2. `:custom-user` → `chain custom/custom.ipxe` → script errors out → no `||` handler → `menu.ipxe` aborts.
3. Bootloader (`roles/netbootxyz/templates/disks/netboot.xyz.j2`) catches the failure → `Local TFTP failed... attempting remote HTTPS` → chains `https://boot.netboot.xyz/menu.ipxe`.
4. Remote `menu.ipxe` chains its own `boot.cfg` (no `set menu`), so `${menu}` is still `custom-user`. Line 38 (`isset \${menu} && goto \${menu}`) jumps directly to `:custom-user` → 404 → abort.
5. Bootloader walks every remaining IPv6/IPv4 × HTTPS/HTTP combo; each one repeats step 4.

## Test plan
- [ ] Set `set menu custom-user` in `boot.cfg` with an intentionally broken local `custom.ipxe` and confirm boot lands on the main menu (locally, and also after the remote fallback kicks in).
- [ ] Confirm a working `custom.ipxe` with `set menu custom-user` still behaves as before.
- [ ] Exercise `:custom-github` and `:custom-url` with a deliberately bad target and confirm the error prompt appears and returns to a usable main menu (no loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)