### PR TITLE
Add arm64 Proxmox VE and gate the Proxmox menu by architecture

### DIFF
--- a/roles/netbootxyz/templates/menu/proxmox.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/proxmox.ipxe.j2
@@ -9,31 +9,36 @@ goto ${menu} ||
 clear proxmox_choice
 clear proxmox_version
 set os Proxmox
-menu ${os}
+set os_arch ${arch}
+iseq ${os_arch} x86_64 && set os_arch amd64 ||
+clear vga_params
+iseq ${os_arch} amd64 && set vga_params vga=791 video=vesafb:ywrap,mtrr ||
+menu ${os} - ${os_arch}
 {% for key, value in endpoints.items() | sort %}
+{% set endpoint_arch = value.arch | default('amd64') %}
 {% if value.os == "proxmox-backup-server" %}
-item --gap ${os} Backup Server
-item pbs-normal ${space} ${os} Backup Server {{ value.version }}
-item pbs-text ${space} ${os} Backup Server {{ value.version }} (Text)
-item pbs-debug ${space} ${os} Backup Server {{ value.version }} (Debug)
+iseq ${os_arch} {{ endpoint_arch }} && item --gap ${os} Backup Server ||
+iseq ${os_arch} {{ endpoint_arch }} && item pbs-normal ${space} ${os} Backup Server {{ value.version }} ||
+iseq ${os_arch} {{ endpoint_arch }} && item pbs-text ${space} ${os} Backup Server {{ value.version }} (Text) ||
+iseq ${os_arch} {{ endpoint_arch }} && item pbs-debug ${space} ${os} Backup Server {{ value.version }} (Debug) ||
 {% endif %}
 {% if value.os == "proxmox-mailgateway" %}
-item --gap ${os} Mail Gateway
-item pmg-normal ${space} ${os} Mail Gateway {{ value.version }}
-item pmg-text ${space} ${os} Mail Gateway {{ value.version }} (Text)
-item pmg-debug ${space} ${os} Mail Gateway {{ value.version }} (Debug)
+iseq ${os_arch} {{ endpoint_arch }} && item --gap ${os} Mail Gateway ||
+iseq ${os_arch} {{ endpoint_arch }} && item pmg-normal ${space} ${os} Mail Gateway {{ value.version }} ||
+iseq ${os_arch} {{ endpoint_arch }} && item pmg-text ${space} ${os} Mail Gateway {{ value.version }} (Text) ||
+iseq ${os_arch} {{ endpoint_arch }} && item pmg-debug ${space} ${os} Mail Gateway {{ value.version }} (Debug) ||
 {% endif %}
 {% if value.os == "proxmox-datacenter-manager" %}
-item --gap ${os} Datacenter Manager
-item pdm-normal ${space} ${os} Datacenter Manager {{ value.version }}
-item pdm-text ${space} ${os} Datacenter Manager {{ value.version }} (Text)
-item pdm-debug ${space} ${os} Datacenter Manager {{ value.version }} (Debug)
+iseq ${os_arch} {{ endpoint_arch }} && item --gap ${os} Datacenter Manager ||
+iseq ${os_arch} {{ endpoint_arch }} && item pdm-normal ${space} ${os} Datacenter Manager {{ value.version }} ||
+iseq ${os_arch} {{ endpoint_arch }} && item pdm-text ${space} ${os} Datacenter Manager {{ value.version }} (Text) ||
+iseq ${os_arch} {{ endpoint_arch }} && item pdm-debug ${space} ${os} Datacenter Manager {{ value.version }} (Debug) ||
 {% endif %}
 {% if value.os == "proxmox-ve" %}
-item --gap ${os} VE
-item pve-normal ${space} ${os} VE {{ value.version }}
-item pve-text ${space} ${os} VE {{ value.version }} (Text)
-item pve-debug ${space} ${os} VE {{ value.version }} (Debug)
+iseq ${os_arch} {{ endpoint_arch }} && item --gap ${os} VE ||
+iseq ${os_arch} {{ endpoint_arch }} && item pve-normal ${space} ${os} VE {{ value.version }} ||
+iseq ${os_arch} {{ endpoint_arch }} && item pve-text ${space} ${os} VE {{ value.version }} (Text) ||
+iseq ${os_arch} {{ endpoint_arch }} && item pve-debug ${space} ${os} VE {{ value.version }} (Debug) ||
 {% endif %}
 {% endfor %}
 choose proxmox_choice || goto proxmox_exit
@@ -90,51 +95,42 @@ goto boot-pbs
 :boot-pbs
 {% for key, value in endpoints.items() | sort %}
 {% if value.os == "proxmox-backup-server" %}
-set kernel_url ${live_endpoint}{{ value.path }}
-set proxmox_version {{ value.version }}
+iseq ${os_arch} {{ value.arch | default('amd64') }} && set kernel_url ${live_endpoint}{{ value.path }} ||
+iseq ${os_arch} {{ value.arch | default('amd64') }} && set proxmox_version {{ value.version }} ||
 {% endif %}
 {% endfor %}
-imgfree
-kernel ${kernel_url}vmlinuz vga=791 video=vesafb:ywrap,mtrr ramdisk_size=16777216 rw quiet ${params} {{ kernel_params }}
-initrd ${kernel_url}initrd
-initrd ${kernel_url}proxmox.iso /proxmox.iso
-boot
+goto boot-proxmox
 
 :boot-pmg
 {% for key, value in endpoints.items() | sort %}
 {% if value.os == "proxmox-mailgateway" %}
-set kernel_url ${live_endpoint}{{ value.path }}
-set proxmox_version {{ value.version }}
+iseq ${os_arch} {{ value.arch | default('amd64') }} && set kernel_url ${live_endpoint}{{ value.path }} ||
+iseq ${os_arch} {{ value.arch | default('amd64') }} && set proxmox_version {{ value.version }} ||
 {% endif %}
 {% endfor %}
-imgfree
-kernel ${kernel_url}vmlinuz vga=791 video=vesafb:ywrap,mtrr ramdisk_size=16777216 rw quiet ${params} {{ kernel_params }}
-initrd ${kernel_url}initrd
-initrd ${kernel_url}proxmox.iso /proxmox.iso
-boot
+goto boot-proxmox
 
 :boot-pdm
 {% for key, value in endpoints.items() | sort %}
 {% if value.os == "proxmox-datacenter-manager" %}
-set kernel_url ${live_endpoint}{{ value.path }}
-set proxmox_version {{ value.version }}
+iseq ${os_arch} {{ value.arch | default('amd64') }} && set kernel_url ${live_endpoint}{{ value.path }} ||
+iseq ${os_arch} {{ value.arch | default('amd64') }} && set proxmox_version {{ value.version }} ||
 {% endif %}
 {% endfor %}
-imgfree
-kernel ${kernel_url}vmlinuz vga=791 video=vesafb:ywrap,mtrr ramdisk_size=16777216 rw quiet ${params} {{ kernel_params }}
-initrd ${kernel_url}initrd
-initrd ${kernel_url}proxmox.iso /proxmox.iso
-boot
+goto boot-proxmox
 
 :boot-pve
 {% for key, value in endpoints.items() | sort %}
 {% if value.os == "proxmox-ve" %}
-set kernel_url ${live_endpoint}{{ value.path }}
-set proxmox_version {{ value.version }}
+iseq ${os_arch} {{ value.arch | default('amd64') }} && set kernel_url ${live_endpoint}{{ value.path }} ||
+iseq ${os_arch} {{ value.arch | default('amd64') }} && set proxmox_version {{ value.version }} ||
 {% endif %}
 {% endfor %}
+goto boot-proxmox
+
+:boot-proxmox
 imgfree
-kernel ${kernel_url}vmlinuz vga=791 video=vesafb:ywrap,mtrr ramdisk_size=16777216 rw quiet ${params} {{ kernel_params }}
+kernel ${kernel_url}vmlinuz ${vga_params} ramdisk_size=16777216 rw quiet ${params} {{ kernel_params }}
 initrd ${kernel_url}initrd
 initrd ${kernel_url}proxmox.iso /proxmox.iso
 boot


### PR DESCRIPTION
Closes #1404.

Proxmox [launched official arm64 support](https://www.proxmox.com/en/about/company-details/press-releases/proxmox-virtual-environment-launches-official-arm64-support) on 2026-08-04, published as `proxmox-ve_9.2-1-arm64.iso`. The issue was originally declined in Jan 2024 because only the unofficial Proxmox-Port build existed — that objection no longer applies.

### Changes to `proxmox.ipxe.j2`

- Derive `os_arch` from `${arch}` (`x86_64` → `amd64`) and gate every menu item on the endpoint's `arch`, defaulting to `amd64` so the existing endpoints need no change.
- Resolve `kernel_url` / `proxmox_version` per arch in the boot blocks.
- Backup Server, Mail Gateway and Datacenter Manager are x86-64 only upstream, so they're now hidden on arm64 rather than offered and failing to boot.
- Drop `vga=791 video=vesafb:ywrap,mtrr` on arm64. Those are x86-only; the arm64 ISO's own `grub.cfg` passes just `ramdisk_size=16777216 rw quiet splash=...`.
- Fold the four byte-identical `:boot-p*` kernel blocks into one `:boot-proxmox`.
- Show the arch in the menu title, matching `clonezilla.ipxe.j2`.

### Depends on

netbootxyz/asset-mirror#14 plus the [`proxmox-ve-arm64`](https://github.com/netbootxyz/asset-mirror/tree/proxmox-ve-arm64) asset branch. Once that workflow runs it commits the `proxmox-ve-arm64` endpoint to `endpoints.yml` here automatically, so no `endpoints.yml` change is included in this PR. Until then this PR is a no-op on arm64 and behaviour-preserving on x86-64.

### Verification

Rendered the template against the current `endpoints.yml` plus a simulated `proxmox-ve-arm64` entry. On `amd64` the output is item-for-item what it is today; on `arm64` only the four Proxmox VE entries appear and `:boot-pve` resolves to the arm64 release path.

I confirmed the arm64 ISO's internal layout by reading its ISO9660 directory over HTTP range requests — `boot/linux26` and `boot/initrd.img`, same as x86-64 — so the mirror's extraction recipe carries over unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)